### PR TITLE
Upgrade 12 default build to 12.0.5

### DIFF
--- a/jetty-embedded-12-ee10/src/test/resources/jetty-env.xml
+++ b/jetty-embedded-12-ee10/src/test/resources/jetty-env.xml
@@ -3,7 +3,7 @@
 
 <Configure id="webAppCtx" class="org.eclipse.jetty.ee10.webapp.WebAppContext">
 
-  <New class="org.eclipse.jetty.ee10.plus.jndi.EnvEntry">
+  <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>
       <Ref refid="webAppCtx"/>
     </Arg>
@@ -11,12 +11,12 @@
     <Arg type="java.lang.String">Embedded</Arg>
     <Arg type="boolean">true</Arg>
   </New>
-  <New class="org.eclipse.jetty.ee10.plus.jndi.EnvEntry">
+  <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>version</Arg>
     <Arg type="java.lang.Integer">6</Arg>
     <Arg type="boolean">true</Arg>
   </New>
-  <New class="org.eclipse.jetty.ee10.plus.jndi.EnvEntry">
+  <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>
       <Ref refid="webAppCtx"/>
     </Arg>

--- a/jetty-embedded-12-ee9/src/test/resources/jetty-env.xml
+++ b/jetty-embedded-12-ee9/src/test/resources/jetty-env.xml
@@ -3,7 +3,7 @@
 
 <Configure id="webAppCtx" class="org.eclipse.jetty.ee9.webapp.WebAppContext">
 
-  <New class="org.eclipse.jetty.ee9.plus.jndi.EnvEntry">
+  <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>
       <Ref refid="webAppCtx"/>
     </Arg>
@@ -11,12 +11,12 @@
     <Arg type="java.lang.String">Embedded</Arg>
     <Arg type="boolean">true</Arg>
   </New>
-  <New class="org.eclipse.jetty.ee9.plus.jndi.EnvEntry">
+  <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>version</Arg>
     <Arg type="java.lang.Integer">6</Arg>
     <Arg type="boolean">true</Arg>
   </New>
-  <New class="org.eclipse.jetty.ee9.plus.jndi.EnvEntry">
+  <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>
       <Ref refid="webAppCtx"/>
     </Arg>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.release>8</maven.compiler.release>
 
-    <jetty12.version>12.0.3</jetty12.version>
+    <jetty12.version>12.0.5</jetty12.version>
 
   </properties>
 


### PR DESCRIPTION
- build(deps): Bump version.jetty from 9.4.49.v20220914 to 12.0.5
- fix upgrade to 12.0.5 because of class nams changes

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-


**Fixes**: #
