### PR TITLE
use indirect buffers in the jetty HttpConfiguration (12 ee10, ee11)

### DIFF
--- a/jetty-embedded-12-ee10/src/main/java/org/jboss/arquillian/container/jetty/embedded_12_ee10/JettyEmbeddedContainer.java
+++ b/jetty-embedded-12-ee10/src/main/java/org/jboss/arquillian/container/jetty/embedded_12_ee10/JettyEmbeddedContainer.java
@@ -146,6 +146,8 @@ public class JettyEmbeddedContainer implements DeployableContainer<JettyEmbedded
             server = new Server();
 
             HttpConfiguration httpConfig = getHttpConfiguration();
+            httpConfig.setUseInputDirectByteBuffers(false);
+            httpConfig.setUseOutputDirectByteBuffers(false);
 
             ConnectionFactory connectionFactory = new HttpConnectionFactory(httpConfig);
             // Setup Connector

--- a/jetty-embedded-12-ee11/src/main/java/org/jboss/arquillian/container/jetty/embedded_12_ee11/JettyEmbeddedContainer.java
+++ b/jetty-embedded-12-ee11/src/main/java/org/jboss/arquillian/container/jetty/embedded_12_ee11/JettyEmbeddedContainer.java
@@ -146,6 +146,8 @@ public class JettyEmbeddedContainer implements DeployableContainer<JettyEmbedded
             server = new Server();
 
             HttpConfiguration httpConfig = getHttpConfiguration();
+            httpConfig.setUseInputDirectByteBuffers(false);
+            httpConfig.setUseOutputDirectByteBuffers(false);
 
             ConnectionFactory connectionFactory = new HttpConnectionFactory(httpConfig);
             // Setup Connector


### PR DESCRIPTION
Some of the websocket TCK tests call `ByteBuffer.array()` in the websocket onMessage, but by default we are using direct buffers so there is no array.

```
java.lang.UnsupportedOperationException
	at java.base/java.nio.ByteBuffer.array(ByteBuffer.java:1505)
	at com.sun.ts.tests.websocket.common.stringbean.StringBeanBinaryDecoder.decode(StringBeanBinaryDecoder.java:34)
	at com.sun.ts.tests.websocket.ee.jakarta.websocket.coder.InitDestroyBinaryDecoder.decode(InitDestroyBinaryDecoder.java:42)
	at com.sun.ts.tests.websocket.ee.jakarta.websocket.coder.InitDestroyBinaryDecoder.decode(InitDestroyBinaryDecoder.java:28)
	at org.eclipse.jetty.ee10.websocket.jakarta.common.messages.DecodedBinaryMessageSink.onWholeMessage(DecodedBinaryMessageSink.java:59)
	at org.eclipse.jetty.websocket.core.messages.ByteBufferMessageSink.invoke(ByteBufferMessageSink.java:127)
	at org.eclipse.jetty.websocket.core.messages.ByteBufferMessageSink.accept(ByteBufferMessageSink.java:79)
	at org.eclipse.jetty.ee10.websocket.jakarta.common.messages.AbstractDecodedMessageSink.accept(AbstractDecodedMessageSink.java:80)
	at org.eclipse.jetty.ee10.websocket.jakarta.common.JakartaWebSocketFrameHandler.acceptMessage(JakartaWebSocketFrameHandler.java:589)
	at org.eclipse.jetty.ee10.websocket.jakarta.common.JakartaWebSocketFrameHandler.onBinary(JakartaWebSocketFrameHandler.java:647)
	at org.eclipse.jetty.ee10.websocket.jakarta.common.JakartaWebSocketFrameHandler.onFrame(JakartaWebSocketFrameHandler.java:243)
	at org.eclipse.jetty.websocket.core.WebSocketCoreSession$IncomingAdaptor.lambda$onFrame$0(WebSocketCoreSession.java:647)
	at org.eclipse.jetty.server.handler.ContextHandler$ScopedContext.run(ContextHandler.java:1517)
	at org.eclipse.jetty.server.handler.ContextHandler$ScopedContext.run(ContextHandler.java:1504)
	at org.eclipse.jetty.websocket.core.server.internal.AbstractHandshaker$1.handle(AbstractHandshaker.java:179)
	at org.eclipse.jetty.websocket.core.WebSocketCoreSession$IncomingAdaptor.onFrame(WebSocketCoreSession.java:647)
	at org.eclipse.jetty.websocket.core.ExtensionStack.onFrame(ExtensionStack.java:113)
	at org.eclipse.jetty.websocket.core.WebSocketCoreSession.onFrame(WebSocketCoreSession.java:463)
	at org.eclipse.jetty.websocket.core.WebSocketConnection.onFrame(WebSocketConnection.java:254)
	at org.eclipse.jetty.websocket.core.WebSocketConnection.fillAndParse(WebSocketConnection.java:447)
```